### PR TITLE
Loopback remote method custom options

### DIFF
--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -43,8 +43,8 @@ var JSON_TYPES = ['boolean', 'string', 'object', 'number'];
  * @property {Array} args The arguments to be used when invoking the `SharedMethod`
  */
 
-function HttpInvocation(method, ctorArgs, args, base, auth, awOptions) {
-  this.awOptions = awOptions;
+function HttpInvocation(method, ctorArgs, args, base, auth, reqOptions) {
+  this.reqOptions = reqOptions;
   this.base = base;
   this.auth = auth;
   this.method = method;
@@ -246,9 +246,9 @@ HttpInvocation.prototype.createRequest = function() {
     req.url += '?' + qs.stringify(query);
   }
 
-  if (this.awOptions && this.awOptions.headers) {
+  if (this.reqOptions && this.reqOptions.headers) {
     req.headers = req.headers || {};
-    Object.assign(req.headers, this.awOptions.headers);
+    Object.assign(req.headers, this.reqOptions.headers);
   }
 
   return req;
@@ -285,8 +285,8 @@ HttpInvocation.prototype.invoke = function(callback) {
         callback(null, stream);
       });
 
-      if (this.awOptions && this.awOptions.retry) {
-        retryRequest(this.req, Object.assign({ request }, this.awOptions.retry)).pipe(mdm);
+      if (this.reqOptions && this.reqOptions.retry) {
+        retryRequest(this.req, Object.assign({ request }, this.reqOptions.retry)).pipe(mdm);
       } else {
         request(this.req).pipe(mdm);
       }
@@ -306,8 +306,8 @@ HttpInvocation.prototype.invoke = function(callback) {
     self.transformResponse(res, body, callback);
   }
 
-  if (this.awOptions && this.awOptions.retry) {
-    retryRequest(this.req, Object.assign({ request }, this.awOptions.retry), requestCallback);
+  if (this.reqOptions && this.reqOptions.retry) {
+    retryRequest(this.req, Object.assign({ request }, this.reqOptions.retry), requestCallback);
   } else {
     request(this.req, requestCallback);
   }

--- a/lib/http-invocation.js
+++ b/lib/http-invocation.js
@@ -19,6 +19,7 @@ var inherits = util.inherits;
 var path = require('path');
 var assert = require('assert');
 var request = require('request');
+var retryRequest = require('retry-request');
 var Dynamic = require('./dynamic');
 var SUPPORTED_TYPES = ['json', 'application/javascript', 'text/javascript'];
 var qs = require('qs');
@@ -42,7 +43,8 @@ var JSON_TYPES = ['boolean', 'string', 'object', 'number'];
  * @property {Array} args The arguments to be used when invoking the `SharedMethod`
  */
 
-function HttpInvocation(method, ctorArgs, args, base, auth) {
+function HttpInvocation(method, ctorArgs, args, base, auth, awOptions) {
+  this.awOptions = awOptions;
   this.base = base;
   this.auth = auth;
   this.method = method;
@@ -244,6 +246,11 @@ HttpInvocation.prototype.createRequest = function() {
     req.url += '?' + qs.stringify(query);
   }
 
+  if (this.awOptions && this.awOptions.headers) {
+    req.headers = req.headers || {};
+    Object.assign(req.headers, this.awOptions.headers);
+  }
+
   return req;
 };
 
@@ -278,7 +285,11 @@ HttpInvocation.prototype.invoke = function(callback) {
         callback(null, stream);
       });
 
-      request(this.req).pipe(mdm);
+      if (this.awOptions && this.awOptions.retry) {
+        retryRequest(this.req, Object.assign({ request }, this.awOptions.retry)).pipe(mdm);
+      } else {
+        request(this.req).pipe(mdm);
+      }
     } else {
       callback(new Error(g.f('unsupported stream type')));
     }
@@ -286,14 +297,20 @@ HttpInvocation.prototype.invoke = function(callback) {
     return;
   }
 
-  request(this.req, function(err, res, body) {
+  function requestCallback(err, res, body) {
     if (err instanceof SyntaxError) {
       if (res.status === 204) err = null;
     }
     if (err) return callback(err);
     self.res = res;
     self.transformResponse(res, body, callback);
-  });
+  }
+
+  if (this.awOptions && this.awOptions.retry) {
+    retryRequest(this.req, Object.assign({ request }, this.awOptions.retry), requestCallback);
+  } else {
+    request(this.req, requestCallback);
+  }
 };
 
 /*

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -125,7 +125,7 @@ RestAdapter.prototype._extractAuth = function(remotes, invokeOptions) {
   return auth;
 };
 
-RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
+RestAdapter.prototype.invoke = function(method, ctorArgs, args, awOptions, callback) {
   assert(this.connection,
     g.f('Cannot invoke method without a connection. See {{RemoteObjects#connect().}}'));
   assert(typeof method === 'string', g.f('method is required when calling {{invoke()}}'));
@@ -144,7 +144,7 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, callback) {
   var auth = this._extractAuth(remotes, invokeOptions);
 
   var invocation = new HttpInvocation(
-    restMethod, ctorArgs, args, this.connection, auth
+    restMethod, ctorArgs, args, this.connection, auth, awOptions
   );
   var ctx = new ContextBase(restMethod);
   ctx.req = invocation.createRequest();

--- a/lib/rest-adapter.js
+++ b/lib/rest-adapter.js
@@ -125,7 +125,7 @@ RestAdapter.prototype._extractAuth = function(remotes, invokeOptions) {
   return auth;
 };
 
-RestAdapter.prototype.invoke = function(method, ctorArgs, args, awOptions, callback) {
+RestAdapter.prototype.invoke = function(method, ctorArgs, args, reqOptions, callback) {
   assert(this.connection,
     g.f('Cannot invoke method without a connection. See {{RemoteObjects#connect().}}'));
   assert(typeof method === 'string', g.f('method is required when calling {{invoke()}}'));
@@ -144,7 +144,7 @@ RestAdapter.prototype.invoke = function(method, ctorArgs, args, awOptions, callb
   var auth = this._extractAuth(remotes, invokeOptions);
 
   var invocation = new HttpInvocation(
-    restMethod, ctorArgs, args, this.connection, auth, awOptions
+    restMethod, ctorArgs, args, this.connection, auth, reqOptions
   );
   var ctx = new ContextBase(restMethod);
   ctx.req = invocation.createRequest();

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mux-demux": "^3.7.9",
     "qs": "^6.2.1",
     "request": "^2.55.0",
+    "retry-request": "^7.0.2",
     "sse": "0.0.6",
     "strong-globalize": "^2.6.6",
     "traverse": "^0.6.6",


### PR DESCRIPTION
## Problem/Description

Loopback does not provide any customisation around the network request. We want the ability to retry a request and provide custom http headers.

## Solution

Implement retry-request for enabling request retries and allow headers to be provided.