### PR TITLE
fix(response): TICS-3636 avoid crash on large json

### DIFF
--- a/lib/http-context.js
+++ b/lib/http-context.js
@@ -650,8 +650,13 @@ HttpContext.prototype.done = function(cb) {
   }
   if (dataExists) {
     if (!this.returnsFile) {
-      operationResults.sendBody(res, data, method);
-      res.end();
+      try {
+        operationResults.sendBody(res, data, method);
+        res.end();
+      } catch (err) {
+        console.error(err);
+        cb(err);
+      }
     } else if (Buffer.isBuffer(data) || typeof(data) === 'string') {
       res.end(data);
     } else if (data.pipe) {


### PR DESCRIPTION
## Problem/Description

```
RangeError: Invalid string length
  at JSON.stringify (<anonymous>)
```

## Solution


Throw a try catch around it.
